### PR TITLE
fix: removes leftover "rk3399-nanopi-r4s-4gb.dtb"

### DIFF
--- a/arch/arm/dts/Makefile
+++ b/arch/arm/dts/Makefile
@@ -131,7 +131,6 @@ dtb-$(CONFIG_ROCKCHIP_RK3399) += \
 	rk3399-nanopi-m4.dtb \
 	rk3399-nanopi-m4-2gb.dtb \
 	rk3399-nanopi-neo4.dtb \
-	rk3399-nanopi-r4s-4gb.dtb \
 	rk3399-nanopi-r4s.dtb \
 	rk3399-orangepi.dtb \
 	rk3399-pinebook-pro.dtb \


### PR DESCRIPTION
Fix compilation errors in `nanopi4-v2020.10 `branch.