### PR TITLE
NanoPI4S : increase space between kernel and ramdisk adress space

### DIFF
--- a/include/configs/rk3399_common.h
+++ b/include/configs/rk3399_common.h
@@ -52,9 +52,9 @@
 	"pxefile_addr_r=0x00600000\0" \
 	"fdt_addr_r=0x01f00000\0" \
 	"kernel_addr_r=0x02080000\0" \
-	"ramdisk_addr_r=0x06000000\0" \
-	"kernel_comp_addr_r=0x08000000\0" \
-	"kernel_comp_size=0x2000000\0"
+	"ramdisk_addr_r=0x06a00000\0" \
+	"kernel_comp_addr_r=0x08a00000\0" \
+	"kernel_comp_size=0x2a00000\0"
 
 #ifndef ROCKCHIP_DEVICE_SETTINGS
 #define ROCKCHIP_DEVICE_SETTINGS


### PR DESCRIPTION
As Linux kernels keep growing bigger (at least on NixOS), the current space can be filled, leading to the following error in u-boot: 
```
ERROR: RD image overlaps OS image (OS=0x2200000..0x60a0000)
```

This patch is heavily inspired from this thread:
https://lore.kernel.org/lkml/87h6u9vpc4.fsf@wireframe/T/